### PR TITLE
Add overwrite mappings for key sheet columns

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,52 @@
+# Site-Problem Synchronisation
+
+This project syncs data from customer spreadsheets with a target Google Sheet. It reads a daily Excel file from Gmail, applies reconciliation rules, and writes updates back to the Sheet.
+
+## Workflow Overview
+
+1. **main.py** orchestrates the process.
+2. **gmail_utils.get_latest_attachment()** downloads the latest Excel attachment matching the Gmail query.
+3. **sheets_utils.read_sheet()** loads the target Google Sheet into a pandas DataFrame.
+4. **reconcile.reconcile_frames()** compares the customer data with the Google Sheet and applies update rules defined in **config.py**.
+5. **sheets_utils.write_sheet()** writes the reconciled DataFrame back to the Sheet.
+
+Temporary files are stored in a temp directory. Logging output is provided by `utils.log`.
+
+## Modules and Key Functions
+
+### main.py
+- `main()`: Entry point that ties everything together. It loads environment variables, fetches the latest attachment, reads/writes the sheet, and invokes reconciliation.
+
+### gmail_utils.py
+- `get_latest_attachment(tmp_dir)`: Searches Gmail using the `GMAIL_QUERY` environment variable, downloads the newest `.xlsx` or `.xlsm` attachment from the newest matching thread, marks the thread as read, and returns the local file path.
+
+### sheets_utils.py
+- `read_sheet()`: Uses the Google Sheets API to read the target spreadsheet defined by `TARGET_SPREADSHEET_ID` and `TARGET_TAB_NAME`. Returns a pandas DataFrame.
+- `write_sheet(df)`: Writes the given DataFrame back to the target sheet.
+
+### reconcile.py
+- `reconcile_frames(src, tgt)`: Core reconciliation logic. Accepts a DataFrame from the customer spreadsheet (`src`) and the current target sheet (`tgt`). Returns the updated DataFrame along with counts of updated rows and warnings. Helper functions `norm()` and `build_key()` normalise strings and construct composite keys used for matching rows.
+
+### config.py
+Defines column mappings and constants used throughout the reconciliation process, such as `FIELD_MAP`, `GS_UID_COL`, `CS_UID_COL`, and names of helper columns like `WARNING_COL` and `UPDATED_COL`.
+
+`FIELD_MAP` specifies how source columns map onto the Google Sheet and whether
+values should overwrite existing cells or only fill blanks. Critical operational
+fields such as `Problem Owner`, `Plan Closed Date`, `Problem Clearance Confirm`,
+`Actual Closed Date` and `HW Remark` are mapped with `mode: "overwrite"` so the
+customer values always replace what is currently on the sheet.
+
+### utils/auth.py
+- `get_creds(scopes)`: Handles OAuth2 authorisation, storing credentials in `token.json` and refreshing them when necessary.
+
+### utils/log.py
+Provides a simple logging utility with functions `info()`, `success()`, `warning()`, and `error()`. The `log` instance from this module is imported wherever logging is needed.
+
+## Running the Script
+
+1. Install dependencies from `requirements.txt`.
+2. Set the necessary environment variables (e.g., Gmail query and Sheet IDs).
+3. Place `credentials.json` from your Google Cloud project in the repository root.
+4. Run `python main.py`.
+
+The script will fetch the latest spreadsheet from Gmail, reconcile it with the Google Sheet, and update the sheet accordingly.

--- a/config.py
+++ b/config.py
@@ -1,7 +1,29 @@
 # Column mapping & helper column names
 FIELD_MAP = {
+    # Map the UID column if it is blank
     "Duplicate in HW DB": {"source": "Unique ID", "mode": "copy_if_blank"},
-    # … (rest of your mapping)
+
+    # Columns that must always mirror the customer spreadsheet
+    "Problem Owner": {
+        "source": "Problem Owner",
+        "mode": "overwrite",
+    },
+    "Plan Closed Date": {
+        "source": "Plan Closed Date",
+        "mode": "overwrite",
+    },
+    "Problem Clearance Confirm": {
+        "source": "Problem Clearance Confirm",
+        "mode": "overwrite",
+    },
+    "Actual Closed Date": {
+        "source": "Actual Closed Date",
+        "mode": "overwrite",
+    },
+    "HW Remark": {
+        "source": "HW Remark",
+        "mode": "overwrite",
+    },
 }
 
 GS_UID_COL      = "Duplicate in HW DB"


### PR DESCRIPTION
## Summary
- map critical sheet columns to their source fields with `overwrite` mode
- clarify in README that these columns are overwritten each run

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_687f1adbb1b8832da8d7a6c5ae4db180