### PR TITLE
Fix column presence checks in reconcile

### DIFF
--- a/reconcile.py
+++ b/reconcile.py
@@ -105,7 +105,12 @@ def reconcile_frames(src: pd.DataFrame,
             for gs_col, mapping in FIELD_MAP.items():
                 cs_col = mapping["source"]
                 mode   = mapping["mode"]
-                old, new = row[gs_col], srow[cs_col]
+
+                if gs_col not in row or cs_col not in srow:
+                    continue
+
+                old = row.get(gs_col, "")
+                new = srow.get(cs_col, "")
 
                 if mode == "overwrite" and old != new:
                     tgt.at[idx, gs_col] = new; changed = True


### PR DESCRIPTION
## Summary
- check column existence before comparing values
- use `.get()` when reading source/target columns

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_687f2125f278832d8688e673907ab1e0