### PR TITLE
Remove unused utils requirement

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,4 +8,3 @@ openpyxl                  # pandas reads xlsx via this
 python-dotenv
 tqdm                      # progress bars (optional)
 numpy
-utils


### PR DESCRIPTION
## Summary
- remove the `utils` dependency from `requirements.txt`
- checked the repo for any references to installing `utils` and found none

## Testing
- `grep -n "pip install utils" -R`

------
https://chatgpt.com/codex/tasks/task_e_687f211f53a0832da1e17cae10cedae2