### PR TITLE
Fix repeated auth prompts

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,9 @@ fields such as `Problem Owner`, `Plan Closed Date`, `Problem Clearance Confirm`,
 customer values always replace what is currently on the sheet.
 
 ### utils/auth.py
-- `get_creds(scopes)`: Handles OAuth2 authorisation, storing credentials in `token.json` and refreshing them when necessary.
+- `get_creds(scopes)`: Handles OAuth2 authorisation, storing credentials in `token.json` and refreshing them when necessary. The cached
+  token remembers previously granted scopes so the browser consent screen is
+  only shown the first time or when new scopes are added.
 
 ### utils/log.py
 Provides a simple logging utility with functions `info()`, `success()`, `warning()`, and `error()`. The `log` instance from this module is imported wherever logging is needed.

--- a/utils/auth.py
+++ b/utils/auth.py
@@ -59,7 +59,9 @@ def get_creds(scopes: Sequence[str]) -> Credentials:
 
     # 1) Load existing token -------------------------------------------------
     if TOKEN_FILE.exists():
-        creds = Credentials.from_authorized_user_file(TOKEN_FILE, scopes=[])
+        # Load previously stored token with its original scopes so that
+        # creds.has_scopes(scopes) can correctly validate them.
+        creds = Credentials.from_authorized_user_file(TOKEN_FILE, scopes=scopes)
 
     # 2) Check validity & required scopes -----------------------------------
     needs_flow = (


### PR DESCRIPTION
## Summary
- ensure stored OAuth token retains scope information
- clarify in README that repeated authorisation is not required once token.json is created

## Testing
- `python -m compileall -q utils/auth.py`
- `python -m compileall -q .`


------
https://chatgpt.com/codex/tasks/task_e_687f2b952c2c832da6c5bdd3ff7c09e2